### PR TITLE
feat: support issue assign via `/assign`, fix typo

### DIFF
--- a/actions/issue_action.go
+++ b/actions/issue_action.go
@@ -41,9 +41,17 @@ func (s *IssueAction) DoAction(event interface{}) error {
 		body := event.Comment.Body
 		log.Infof("Issue comments: %+v , %+v coming", event.Sender.Login, body)
 		switch body := strings.ToLower(body); {
-		case strings.HasPrefix(body, "/assignme"), strings.HasPrefix(body, "/assign"):
+		case strings.HasPrefix(body, "/assign"):
 			{
-				s.client.IssueAssignTo(int(event.Issue.Number), event.Sender.Login)
+				var user string
+				if body == "/assign" || body == "/assignme" {
+					user = event.Sender.Login
+				} else {
+					user = strings.TrimSpace(strings.TrimPrefix(body, "/assign @"))
+				}
+				if err := s.client.IssueAssignTo(int(event.Issue.Number), user); err != nil {
+					return err
+				}
 				s.client.AddLabelToIssue(int(event.Issue.Number), "community-take")
 			}
 		case strings.HasPrefix(body, "/review "):

--- a/actions/issue_action.go
+++ b/actions/issue_action.go
@@ -41,7 +41,7 @@ func (s *IssueAction) DoAction(event interface{}) error {
 		body := event.Comment.Body
 		log.Infof("Issue comments: %+v , %+v coming", event.Sender.Login, body)
 		switch body := strings.ToLower(body); {
-		case strings.HasPrefix(body, "/assignme"):
+		case strings.HasPrefix(body, "/assignme"), strings.HasPrefix(body, "/assign"):
 			{
 				s.client.IssueAssignTo(int(event.Issue.Number), event.Sender.Login)
 				s.client.AddLabelToIssue(int(event.Issue.Number), "community-take")

--- a/cmd/fusebots.go
+++ b/cmd/fusebots.go
@@ -67,7 +67,7 @@ func main() {
 		payload, err := hook.Parse(r, github.ReleaseEvent, github.PullRequestEvent, github.IssueCommentEvent, github.IssuesEvent)
 		if err != nil {
 			if err == github.ErrEventNotFound {
-				log.Errorf("Unhanle gihutb event: %v", err)
+				log.Errorf("Unhandle github event: %v", err)
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: unconsolable <chenzhipeng2012@gmail.com>

Close datafuselabs/databend#2890

What is changed:
- Add `/assign` command support
- Fix a typo
